### PR TITLE
feat: drop armv7 support and improve build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,16 +61,13 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-22.04-arm
             target: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - name: Setup QEMU
-        if: matrix.platform.target != 'x86_64'
-        uses: docker/setup-qemu-action@v2
       - name: copy README.md
         run: |
           cp README.md pyrxing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,6 @@ jobs:
             target: x86_64
           - runner: ubuntu-22.04
             target: aarch64
-          - runner: ubuntu-22.04
-            target: armv7
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -65,8 +63,6 @@ jobs:
             target: x86_64
           - runner: ubuntu-22.04
             target: aarch64
-          - runner: ubuntu-22.04
-            target: armv7
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -85,12 +81,25 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.platform.target }}
       - name: Build wheels
         run: |
+          case "${{ matrix.platform.target }}" in
+            "x86_64")  RUST_TARGET="stable-x86_64-unknown-linux-musl" ;;
+            "aarch64") RUST_TARGET="stable-aarch64-unknown-linux-musl" ;;
+          esac
+          
+          case "${{ matrix.platform.target }}" in
+            "x86_64")  DOCKER_PLATFORM="linux/amd64" ;;
+            "aarch64") DOCKER_PLATFORM="linux/arm64" ;;
+          esac
+          
           docker run --rm \
+            --platform $DOCKER_PLATFORM \
             -v $(pwd):/workspace \
             -w /workspace/pyrxing \
             python:3.13.5-alpine3.22 \
             sh -c "
-              apk add --no-cache build-base cmake g++ gcc musl-dev git ninja rust cargo &&
+              apk add --no-cache build-base cmake g++ gcc musl-dev git ninja curl &&
+              curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUST_TARGET &&
+              source ~/.cargo/env &&
               pip install maturin patchelf &&
               maturin build --release -i ${TARGET_PYTHON} --out dist
             "

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This library offers efficient barcode scanning in pure Python environments, with
 ### Platforms
 
 * **Linux** (manylinux & musllinux wheels)
-  * Architectures: `x86_64`, `aarch64`, `armv7`
+  * Architectures: `x86_64`, `aarch64`
 * **macOS**
   * Universal binaries for both Intel and Apple Silicon (arm64)
 * **Windows**


### PR DESCRIPTION
- Remove armv7 from CI build matrix
- Migrate from Alpine rust package to rustup for better reliability
- Update documentation to reflect x86_64 and aarch64 support only

BREAKING CHANGE: armv7 wheels no longer provided due to technical limitations