### PR TITLE
feat: add PyPI attestations support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,22 +225,17 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [linux, musllinux, macos, windows, sdist]
     permissions:
-      # Use to sign the release artifacts
+      # OIDC token for Trusted Publishing
       id-token: write
-      # Used to upload release artifacts
-      contents: write
-      # Used to generate artifact attestation
-      attestations: write
     steps:
       - uses: actions/download-artifact@v4
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
         with:
-          subject-path: 'wheels-*/*'
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+          packages-dir: dist/
+          skip-existing: true
+          attestations: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [ "pyrxing", "reader_core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Takanobu Nagumo <nagumo5683@gmail.com>"]
 license = "Apache-2.0"
 edition = "2024"


### PR DESCRIPTION
## Summary

This PR adds support for PyPI attestations to enable cryptographic verification of package provenance.

- Replaced `maturin upload` with `pypa/gh-action-pypi-publish` for automatic attestation generation and upload
- Configured Trusted Publishing on PyPI to eliminate the need for API tokens
- Updated artifact download step to merge all wheels into a single `dist/` directory
- Removed unnecessary permissions (`contents: write`, `attestations: write`)
- Bumped version to 0.4.2

## What are PyPI Attestations?

Attestations allow users to cryptographically verify that published packages were built from the public GitHub Actions workflow at a specific commit, improving supply chain security and preventing tampering.

## Changes

### Workflow Changes
- **Before**: Used `maturin upload` with API token authentication
- **After**: Uses `pypa/gh-action-pypi-publish` with OIDC-based Trusted Publishing

### Benefits
- ✅ Automatic attestation generation and upload
- ✅ No need to manage API tokens
- ✅ Users can verify package provenance
- ✅ Improved supply chain security

## Testing

This change will be tested when the next release is created by:
1. Merging this PR to master
2. Creating and pushing a `v0.4.2` tag
3. Verifying that the GitHub Actions workflow completes successfully
4. Confirming attestations appear on PyPI package page

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)