### PR TITLE
fix: remove Windows x86 (32-bit) build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,8 +168,6 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
-          - runner: windows-latest
-            target: x86
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This library offers efficient barcode scanning in pure Python environments, with
 * **macOS**
   * Universal binaries for both Intel and Apple Silicon (arm64)
 * **Windows**
-  * Architectures: `x64`, `x86`
+  * Architectures: `x64`
 
 ### Python Versions
 


### PR DESCRIPTION
## Summary

This PR removes the Windows x86 (32-bit) build target from the CI workflow.

## Problem

PR #18 introduced PyPI attestations support, but the Windows x86 build started failing because:
- GitHub Actions runners don't provide 32-bit Python interpreters by default
- The build tried to find a 32-bit Python but only 64-bit versions were available
- This caused `maturin` to fail with "Could not find any interpreters"

## Solution

Remove the Windows x86 (32-bit) target from the build matrix:
- Windows 32-bit usage is negligible in modern environments
- Simplifies CI/CD maintenance
- All other platforms (Linux x86_64/aarch64, macOS, Windows x64, musllinux) remain supported

## Changes

- Removed `x86` from Windows build matrix in `.github/workflows/build.yml`
- Updated README to reflect supported architectures

## Testing

The build workflow will run on push to master, verifying that all remaining platforms build successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)