### PR TITLE
feat: add Python 3.14 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: build
 
 env:
-  TARGET_PYTHON: "python3.13 python3.12 python3.11"
+  TARGET_PYTHON: "python3.14 python3.13 python3.12 python3.11"
 
 on:
   push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [ "pyrxing", "reader_core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Takanobu Nagumo <nagumo5683@gmail.com>"]
 license = "Apache-2.0"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This library offers efficient barcode scanning in pure Python environments, with
 
 ### Python Versions
 
-Python 3.11+
+Python 3.11 - 3.14
 
 ---
 

--- a/pyrxing/Cargo.toml
+++ b/pyrxing/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 reader_core = { path = "../reader_core" }
-pyo3 = { version = "0.24.0", features = ["extension-module"] }
+pyo3 = { version = "0.26.0", features = ["extension-module"] }
 image = "0.25.6"

--- a/pyrxing/pyproject.toml
+++ b/pyrxing/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 
     "Programming Language :: Python :: Implementation :: CPython",
 


### PR DESCRIPTION
## Summary

- Add Python 3.14 to supported Python versions
- Update CI build configuration to include Python 3.14 wheels
- Bump version to 0.4.3

## Changes

- Updated `TARGET_PYTHON` in `.github/workflows/build.yml` to include `python3.14`
- Added Python 3.14 classifier in `pyrxing/pyproject.toml`
- Updated README to reflect support for Python 3.11 - 3.14
- Incremented version from 0.4.2 to 0.4.3 in `Cargo.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)